### PR TITLE
-c version filter

### DIFF
--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -145,6 +145,7 @@ while (( "$#" )); do
         -c|--check)
             single_action
             run_action="check"
+            argarg_required=1
             ;;
         -l|--local-list)
             single_action
@@ -415,7 +416,7 @@ load_remote_versions () {
                 [[ $use_rc -eq 0 ]] && continue
                 line="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
             fi
-            [[ -n "$2" ]] && [[ ! "$line" =~ $2 ]] && continue
+            [[ -n "$2" ]] && [[ ! "$line" =~ "$2" ]] && continue
             REMOTE_VERSIONS+=("$line")
         done < <(parse_remote_versions | sort -V)
         unset IFS
@@ -482,9 +483,17 @@ Optional:
     check)
         check_environment
 
-        logn "Finding latest version available on $ppa_host"
-        latest_version=$(latest_remote_version)
-        log ": $latest_version"
+	if [ -z "${action_data[0]}" ]; then
+	        logn "Finding latest version available on $ppa_host"
+        	latest_version=$(latest_remote_version)
+        	log ": $latest_version"
+	else
+		version_filter="v"${action_data[0]#v}
+		logn "Finding latest version matching '${version_filter}' available on $ppa_host"
+                latest_version=$(latest_remote_version "${version_filter}")
+                log ": $latest_version"
+
+	fi
 
         logn "Finding latest installed version"
         installed_version=$(latest_local_version)

--- a/ubuntu-mainline-kernel.sh
+++ b/ubuntu-mainline-kernel.sh
@@ -450,7 +450,7 @@ case $run_action in
 Download & install the latest kernel available from $ppa_host$ppa_uri
 
 Arguments:
-  -c               Check if a newer kernel version is available
+  -c [VERSION]     Check if a newer kernel version is available. Optional VERSION filter 
   -i [VERSION]     Install kernel VERSION, see -l for list. You don't have to prefix
                    with v. E.g. -i 4.9 is the same as -i v4.9. If version is
                    omitted the latest available version will be installed


### PR DESCRIPTION
add support for version filter to `-c | --check` command. For example:  

```
#> ./ubuntu-mainline-kernel.sh -c 5.1.
Finding latest version matching 'v5.1.' available on kernel.ubuntu.com: v5.1.21
```